### PR TITLE
Binary info

### DIFF
--- a/backtrace.h
+++ b/backtrace.h
@@ -157,15 +157,20 @@ extern int backtrace_pcinfo (struct backtrace_state *state, uintptr_t pc,
 			     void *data);
 
 /* The type of the callback argument to backtrace_syminfo.  DATA and
-   PC are the arguments passed to backtrace_syminfo.  SYMNAME is the
-   name of the symbol for the corresponding code.  SYMVAL is the
-   value and SYMSIZE is the size of the symbol.  SYMNAME will be NULL
-   if no error occurred but the symbol could not be found.  */
+   PC are the arguments passed to backtrace_syminfo.  SYMNAME is the name of
+   the symbol for the corresponding code.  SYMVAL is the value and SYMSIZE is
+   the size of the symbol.  SYMNAME will be NULL if no error occurred but the
+   symbol could not be found. BINARY_FILENAME is the name of the shared object
+   filename or NULL if the symbol was found in the executable itself or the
+   symbol could not be found. BASE_ADDRESS is the base address of the shared
+   object or 0 if the symbol could not be found.*/
 
 typedef void (*backtrace_syminfo_callback) (void *data, uintptr_t pc,
 					    const char *symname,
 					    uintptr_t symval,
-					    uintptr_t symsize);
+					    uintptr_t symsize,
+					    const char* binary_filename,
+					    uintptr_t base_address);
 
 /* Given ADDR, an address or program counter in the current program,
    call the callback information with the symbol name and value

--- a/fileline.c
+++ b/fileline.c
@@ -326,7 +326,9 @@ void
 backtrace_syminfo_to_full_callback (void *data, uintptr_t pc,
 				    const char *symname,
 				    uintptr_t symval ATTRIBUTE_UNUSED,
-				    uintptr_t symsize ATTRIBUTE_UNUSED)
+				    uintptr_t symsize ATTRIBUTE_UNUSED,
+				    const char *binary_filename ATTRIBUTE_UNUSED,
+				    uintptr_t base_address ATTRIBUTE_UNUSED)
 {
   struct backtrace_call_full *bdata = (struct backtrace_call_full *) data;
 

--- a/internal.h
+++ b/internal.h
@@ -351,7 +351,9 @@ struct backtrace_call_full
 extern void backtrace_syminfo_to_full_callback (void *data, uintptr_t pc,
 						const char *symname,
 						uintptr_t symval,
-						uintptr_t symsize);
+						uintptr_t symsize,
+						const char * binary_filename,
+						uintptr_t base_address);
 
 /* An error callback that corresponds to
    backtrace_syminfo_to_full_callback.  */

--- a/macho.c
+++ b/macho.c
@@ -746,9 +746,9 @@ macho_syminfo (struct backtrace_state *state, uintptr_t addr,
     }
 
   if (sym == NULL)
-    callback (data, addr, NULL, 0, 0);
+    callback (data, addr, NULL, 0, 0, 0, 0);
   else
-    callback (data, addr, sym->name, sym->address, 0);
+    callback (data, addr, sym->name, sym->address, 0, 0, 0);
 }
 
 /* Look through a fat file to find the relevant executable.  Returns 1


### PR DESCRIPTION
include executable binary name during back trace